### PR TITLE
Fix for binary incompatability with 1.27.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.playeranalytics</groupId>
     <artifactId>Extension-DiscordSRV</artifactId>
-    <version>1.25.1-R1.4</version>
+    <version>1.27.0-R1.4</version>
     <build>
         <plugins>
             <plugin>
@@ -54,7 +54,7 @@
         <dependency> <!-- Plan API -->
             <groupId>com.djrapitops</groupId>
             <artifactId>plan-api</artifactId>
-            <version>5.2-R0.1</version>
+            <version>5.2-R0.9</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.discordsrv</groupId>
             <artifactId>discordsrv</artifactId>
-            <version>1.25.1</version>
+            <version>1.27.0</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
AccountLinkManager was changed to a interface from a class breaking existing usages, updating to compile against the updated dependency is sufficient to fix the issue